### PR TITLE
fix: migrage mergetool from meld to Codium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage
 
 # FD2 stuff
 docker/db
+docker/db.*.tar.bz2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     depends_on:
       - db
       - farmos
-    image: farmdata2/fd2dev:fd2.1
+    image: farmdata2/fd2dev:fd2.2
     container_name: fd2_dev
     init: true
     volumes:
@@ -47,7 +47,7 @@ services:
       # Preserve the fd2dev user's home directory on a docker volume.
       # Bump the version here and in volumes below
       # if image rebuild requires new home.
-      - fd2dev_home_fd2.1:/home/fd2dev
+      - fd2dev_home_fd2.2:/home/fd2dev
       # Mount a docker volume into which the farmOS database will be built.
       # This allows switching the database from within the dev container.
       # This has significantly better performance than mounting a host directory.
@@ -62,4 +62,4 @@ services:
 volumes:
   farmos2_db_fd2.1:
   farmos2_config_fd2.1:
-  fd2dev_home_fd2.1:
+  fd2dev_home_fd2.2:


### PR DESCRIPTION
**Pull Request Description**

Migrates to a new fd2dev container image that uses Codium as the merge tool rather than meld.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
